### PR TITLE
Added CSP nonce to Adyen PayPal initialisation

### DIFF
--- a/view/frontend/templates/adyen.phtml
+++ b/view/frontend/templates/adyen.phtml
@@ -5,6 +5,10 @@
  * @var \BlueFinch\CheckoutAdyen\ViewModel\Assets $assetViewModel
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
+use BlueFinch\Checkout\Helper\CspHelper;
+
+$cspHelper = $this->helper(CspHelper::class);
+$cspNonce = $cspHelper->getCspNonce();
 
 $assetViewModel = $block->getAssetViewModel();
 
@@ -39,6 +43,8 @@ $styles = $assetViewModel->getDistViewFileUrl('BlueFinch_CheckoutAdyen::js/check
     window.bluefinchCheckout.paymentIcons.AdyenIcons = "{$escaper->escapeJs($paymentIcons)}";
     window.bluefinchCheckout.callbacks.onCreate.adyenOnCreate = "{$escaper->escapeJs($onCreate)}";
     window.bluefinchCheckout.callbacks.onLogin.adyenOnLogin = "{$escaper->escapeJs($onLogin)}";
+
+    window.adyenCspNonce = "$cspNonce";
 script; ?>
 <?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false) ?>
 

--- a/view/frontend/web/js/checkout/src/components/DropIn/PaymentMethods/PaymentMethods.vue
+++ b/view/frontend/web/js/checkout/src/components/DropIn/PaymentMethods/PaymentMethods.vue
@@ -218,6 +218,9 @@ export default {
         threeDS2: {
           challengeWindowSize: '05',
         },
+        paypal: {
+          cspNonce: window.adyenCspNonce,
+        },
       },
     };
 


### PR DESCRIPTION
<!-- 

Do not commit any changes to the `view/frontend/web/js/checkout/dist` directory 

See .github/CONTRIBUTING.md for local workflow recommendations

-->

When initialising the PayPal buttons through Adyen we were running into the same CSP report error.

Added a CSP nonce to the page which is picked up and passed through to Adyen which then passes that on when initialising the PayPal buttons which prevents the CSP error.
