### PR TITLE
Switch over to use BlueFinch Checkout CSP

### DIFF
--- a/view/frontend/templates/adyen.phtml
+++ b/view/frontend/templates/adyen.phtml
@@ -5,10 +5,6 @@
  * @var \BlueFinch\CheckoutAdyen\ViewModel\Assets $assetViewModel
  * @var \Magento\Framework\View\Helper\SecureHtmlRenderer $secureRenderer
  */
-use BlueFinch\Checkout\Helper\CspHelper;
-
-$cspHelper = $this->helper(CspHelper::class);
-$cspNonce = $cspHelper->getCspNonce();
 
 $assetViewModel = $block->getAssetViewModel();
 
@@ -43,8 +39,6 @@ $styles = $assetViewModel->getDistViewFileUrl('BlueFinch_CheckoutAdyen::js/check
     window.bluefinchCheckout.paymentIcons.AdyenIcons = "{$escaper->escapeJs($paymentIcons)}";
     window.bluefinchCheckout.callbacks.onCreate.adyenOnCreate = "{$escaper->escapeJs($onCreate)}";
     window.bluefinchCheckout.callbacks.onLogin.adyenOnLogin = "{$escaper->escapeJs($onLogin)}";
-
-    window.adyenCspNonce = "$cspNonce";
 script; ?>
 <?= /* @noEscape */ $secureRenderer->renderTag('script', [], $scriptString, false) ?>
 

--- a/view/frontend/web/js/checkout/src/components/DropIn/PaymentMethods/PaymentMethods.vue
+++ b/view/frontend/web/js/checkout/src/components/DropIn/PaymentMethods/PaymentMethods.vue
@@ -219,7 +219,7 @@ export default {
           challengeWindowSize: '05',
         },
         paypal: {
-          cspNonce: window.adyenCspNonce,
+          cspNonce: window.cspNonce,
         },
       },
     };


### PR DESCRIPTION
Rather than creating a CSP nonce specifically for Adyen we can just use the one provided by BlueFinch Checkout.

<!-- 

Do not commit any changes to the `view/frontend/web/js/checkout/dist` directory 

See .github/CONTRIBUTING.md for local workflow recommendations

-->
